### PR TITLE
Increasing ARM template deployment timeout to 20m

### DIFF
--- a/builtin/providers/azurerm/resource_arm_template_deployment.go
+++ b/builtin/providers/azurerm/resource_arm_template_deployment.go
@@ -110,7 +110,7 @@ func resourceArmTemplateDeploymentCreate(d *schema.ResourceData, meta interface{
 		Pending: []string{"creating", "updating", "accepted", "running"},
 		Target:  []string{"succeeded"},
 		Refresh: templateDeploymentStateRefreshFunc(client, resGroup, name),
-		Timeout: 10 * time.Minute,
+		Timeout: 20 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf("Error waiting for Template Deployment (%s) to become available: %s", name, err)


### PR DESCRIPTION
Template deployments with multiple extensions can last more than 10 minutes. Fixing that by increasing the time to 20 minutes.
